### PR TITLE
metrics: compute interval metrics without GetInternalIntervalMetrics

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -207,6 +207,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//proto",
         "@com_github_google_btree//:btree",
+        "@com_github_hdrhistogram_hdrhistogram_go//:hdrhistogram-go",
         "@com_github_kr_pretty//:pretty",
         "@io_etcd_go_etcd_raft_v3//:raft",
         "@io_etcd_go_etcd_raft_v3//raftpb",

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1647,6 +1647,12 @@ Note that the measurement does not include the duration for replicating the eval
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaPebbleFsyncLatency = metric.Metadata{
+		Name:        "pebble.fsync.latency",
+		Help:        "TODO",
+		Measurement: "Fsync Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 	metaPebbleFlushUtilization = metric.Metadata{
 		Name:        "pebble.flush.utilization",
 		Help:        "The percentage of time spent flushing in the pebble flush loop",
@@ -1945,7 +1951,8 @@ type StoreMetrics struct {
 	ReplicaReadBatchEvaluationLatency  *metric.Histogram
 	ReplicaWriteBatchEvaluationLatency *metric.Histogram
 
-	FlushUtilization *metric.GaugeFloat64
+	FlushUtilization   *metric.GaugeFloat64
+	PebbleFsyncLatency *metric.LFHistogram
 }
 
 type tenantMetricsRef struct {
@@ -2479,7 +2486,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReplicaWriteBatchEvaluationLatency: metric.NewHistogram(
 			metaReplicaWriteBatchEvaluationLatency, histogramWindow, metric.IOLatencyBuckets,
 		),
-		FlushUtilization: metric.NewGaugeFloat64(metaPebbleFlushUtilization),
+		FlushUtilization:   metric.NewGaugeFloat64(metaPebbleFlushUtilization),
+		PebbleFsyncLatency: metric.NewLFHistogram(metaPebbleFsyncLatency),
+		//PebbleFsyncLatency: metric.NewHistogram(metaPebbleFsyncLatency, histogramWindow, metric.IOLatencyBuckets),
 	}
 
 	{

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -16,6 +16,7 @@ import (
 	gosql "database/sql"
 	"encoding/hex"
 	"fmt"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"math"
 	"net/url"
 	"os"

--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
+        "@com_github_hdrhistogram_hdrhistogram_go//:hdrhistogram-go",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/graphite",
         "@com_github_prometheus_client_model//go",


### PR DESCRIPTION
Remove dependence on the `GetInternalIntervalMetrics` as this method
resets the interval following each call. This results in issues if two
clients interact with `GetInternalIntervalMetrics` as they will reset
the other client’s interval. Ex: Client A calls every 5 seconds and
Client B calls every 10 seconds. Client B will end up getting metrics at
a 5-second interval since `GetInternalIntervalMetrics` resets the
interval on each call.

The `admission.StoreMetrics` are updated to remove the
`InternalIntervalField` as these metrics need to be computed based off
the current metrics `admission.StoreMetrics.Metrics` and the previous
metrics. The storage of the previous metrics is left up to the client.
Removing the field was chosen instead of setting it to a `nil` value as
it would be confusing to return the `StoreMetrics` and require the
client to populate the field when they compute the necessary metrics.

For the admission control use case, the flush metrics are computed as
part of `ioLoadListener.adjustTokens` with the previous metrics being
initialized in `ioLoadListener.pebbleMetricsTick` and stored on the
`ioLoadListenerState` as `cumStoreInternalMetrics`.

Additionally, make a copy of the `pebble.InternalIntervalMetrics` in
order to move away from using the `pebble` version of the interval
metrics as these metrics are now the responsibility of the caller to
compute.

Release note: None